### PR TITLE
Fix `npm start` issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A slack bot for keeping your team fit",
   "main": "main.js",
   "scripts": {
+    "start": "node main.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Heroku attempts to start the bot with `npm start`. I added a start command to the package file.
